### PR TITLE
Update default language server to python-lsp-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Adds [xonsh](https://xon.sh/) language support for VSCode Editor.
   + code snippets inside `markdown` files also work.
 
 * Autocompletion with Language server protocol.
-  + [pyls](https://github.com/palantir/python-language-server/) is used for jedi completion.
+  + [pylsp](https://github.com/python-lsp/python-lsp-server) is used for jedi completion.
 
 ## Installation
 
@@ -19,16 +19,18 @@ Hit `F1` and enter the `ext install jnoortheen.xonsh` command or search for `xon
 
 ### Python-language-server
 
-* Make sure that [ `pyls` ](https://github.com/palantir/python-language-server/) is installed and available on the `$PATH`
+* Make sure that [ `pylsp` ](https://github.com/python-lsp/python-lsp-server) is installed and available on the `$PATH`
 * I recommend using [pipx](https://github.com/pipxproject/pipx/)
 
 ``` sh
-pipx install 'python-language-server[all]'
+pipx install 'python-lsp-server[all]'
 ```
+
+* Previous versions of this extension used the [ older `pyls` ](https://github.com/palantir/python-language-server/) by Palantir. Further development is taking place in the community fork [pylsp](https://github.com/python-lsp/python-lsp-server). Due to the way configuration variables are handled, this extension is NOT backwards compatible with `pyls`. If you must use `pyls`, please downgrade to version 0.1.13.
 
 ## Contributing
 
-I have created this extension since there were none to support Xonsh. PRs are welcome to add new features/fixes. 
+I have created this extension since there were none to support Xonsh. PRs are welcome to add new features/fixes.
 
 Please make sure that you
 * Document the purpose of functions and classes.

--- a/package.json
+++ b/package.json
@@ -50,291 +50,292 @@
         "configuration": "./language-configuration.json"
       }
     ],
-    "configuration": {
-      "type": "object",
-      "title": "Xonsh Language Server configuration",
-      "properties": {
-        "pyls.executable": {
-          "type": "string",
-          "default": "pyls",
-          "description": "Language server executable"
-        },
-        "pyls.configurationSources": {
-          "type": "array",
-          "default": [
-            "pycodestyle",
-            "pyflakes"
-          ],
-          "description": "List of configuration sources to use.",
-          "items": {
+    "configuration": [
+      {
+        "title": "Xonsh Language Server configuration",
+        "properties": {
+          "pylsp.executable": {
             "type": "string",
-            "enum": [
+            "default": "pylsp",
+            "description": "Language server executable"
+          },
+          "pylsp.configurationSources": {
+            "type": "array",
+            "default": [
               "pycodestyle",
               "pyflakes"
-            ]
+            ],
+            "description": "List of configuration sources to use.",
+            "items": {
+              "type": "string",
+              "enum": [
+                "pycodestyle",
+                "pyflakes"
+              ]
+            },
+            "uniqueItems": true
           },
-          "uniqueItems": true
-        },
-        "pyls.plugins.jedi.extra_paths": {
-          "type": "array",
-          "default": [],
-          "description": "Define extra paths for jedi.Script."
-        },
-        "pyls.plugins.jedi.env_vars": {
-          "type": "dictionary",
-          "default": null,
-          "description": "Define environment variables for jedi.Script and Jedi.names."
-        },
-        "pyls.plugins.jedi.environment": {
-          "type": "string",
-          "default": null,
-          "description": "Define environment for jedi.Script and Jedi.names."
-        },
-        "pyls.plugins.jedi_completion.enabled": {
-          "type": "boolean",
-          "default": true,
-          "description": "Enable or disable the plugin."
-        },
-        "pyls.plugins.jedi_completion.include_params": {
-          "type": "boolean",
-          "default": true,
-          "description": "Auto-completes methods and classes with tabstops for each parameter."
-        },
-        "pyls.plugins.jedi_completion.include_class_objects": {
-          "type": "boolean",
-          "default": true,
-          "description": "Adds class objects as a separate completion item."
-        },
-        "pyls.plugins.jedi_completion.fuzzy": {
-          "type": "boolean",
-          "default": false,
-          "description": "Enable fuzzy when requesting autocomplete."
-        },
-        "pyls.plugins.jedi_definition.enabled": {
-          "type": "boolean",
-          "default": true,
-          "description": "Enable or disable the plugin."
-        },
-        "pyls.plugins.jedi_definition.follow_imports": {
-          "type": "boolean",
-          "default": true,
-          "description": "The goto call will follow imports."
-        },
-        "pyls.plugins.jedi_definition.follow_builtin_imports": {
-          "type": "boolean",
-          "default": true,
-          "description": "If follow_imports is True will decide if it follow builtin imports."
-        },
-        "pyls.plugins.jedi_hover.enabled": {
-          "type": "boolean",
-          "default": true,
-          "description": "Enable or disable the plugin."
-        },
-        "pyls.plugins.jedi_references.enabled": {
-          "type": "boolean",
-          "default": true,
-          "description": "Enable or disable the plugin."
-        },
-        "pyls.plugins.jedi_signature_help.enabled": {
-          "type": "boolean",
-          "default": true,
-          "description": "Enable or disable the plugin."
-        },
-        "pyls.plugins.jedi_symbols.enabled": {
-          "type": "boolean",
-          "default": true,
-          "description": "Enable or disable the plugin."
-        },
-        "pyls.plugins.jedi_symbols.all_scopes": {
-          "type": "boolean",
-          "default": true,
-          "description": "If True lists the names of all scopes instead of only the module namespace."
-        },
-        "pyls.plugins.mccabe.enabled": {
-          "type": "boolean",
-          "default": false,
-          "description": "Enable or disable the plugin."
-        },
-        "pyls.plugins.mccabe.threshold": {
-          "type": "number",
-          "default": 15,
-          "description": "The minimum threshold that triggers warnings about cyclomatic complexity."
-        },
-        "pyls.plugins.preload.enabled": {
-          "type": "boolean",
-          "default": true,
-          "description": "Enable or disable the plugin."
-        },
-        "pyls.plugins.preload.modules": {
-          "type": "array",
-          "default": null,
-          "items": {
-            "type": "string"
+          "pylsp.plugins.jedi.extra_paths": {
+            "type": "array",
+            "default": [],
+            "description": "Define extra paths for jedi.Script."
           },
-          "uniqueItems": true,
-          "description": "List of modules to import on startup"
-        },
-        "pyls.plugins.pycodestyle.enabled": {
-          "type": "boolean",
-          "default": false,
-          "description": "Enable or disable the plugin."
-        },
-        "pyls.plugins.pycodestyle.exclude": {
-          "type": "array",
-          "default": null,
-          "items": {
-            "type": "string"
+          "pylsp.plugins.jedi.env_vars": {
+            "type": "dictionary",
+            "default": null,
+            "description": "Define environment variables for jedi.Script and Jedi.names."
           },
-          "uniqueItems": true,
-          "description": "Exclude files or directories which match these patterns."
-        },
-        "pyls.plugins.pycodestyle.filename": {
-          "type": "array",
-          "default": null,
-          "items": {
-            "type": "string"
+          "pylsp.plugins.jedi.environment": {
+            "type": "string",
+            "default": null,
+            "description": "Define environment for jedi.Script and Jedi.names."
           },
-          "uniqueItems": true,
-          "description": "When parsing directories, only check filenames matching these patterns."
-        },
-        "pyls.plugins.pycodestyle.select": {
-          "type": "array",
-          "default": null,
-          "items": {
-            "type": "string"
+          "pylsp.plugins.jedi_completion.enabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "Enable or disable the plugin."
           },
-          "uniqueItems": true,
-          "description": "Select errors and warnings"
-        },
-        "pyls.plugins.pycodestyle.ignore": {
-          "type": "array",
-          "default": null,
-          "items": {
-            "type": "string"
+          "pylsp.plugins.jedi_completion.include_params": {
+            "type": "boolean",
+            "default": true,
+            "description": "Auto-completes methods and classes with tabstops for each parameter."
           },
-          "uniqueItems": true,
-          "description": "Ignore errors and warnings"
-        },
-        "pyls.plugins.pycodestyle.hangClosing": {
-          "type": "boolean",
-          "default": null,
-          "description": "Hang closing bracket instead of matching indentation of opening bracket's line."
-        },
-        "pyls.plugins.pycodestyle.maxLineLength": {
-          "type": "number",
-          "default": null,
-          "description": "Set maximum allowed line length."
-        },
-        "pyls.plugins.pydocstyle.enabled": {
-          "type": "boolean",
-          "default": false,
-          "description": "Enable or disable the plugin."
-        },
-        "pyls.plugins.pydocstyle.convention": {
-          "type": "string",
-          "default": null,
-          "enum": [
-            "pep257",
-            "numpy"
-          ],
-          "description": "Choose the basic list of checked errors by specifying an existing convention."
-        },
-        "pyls.plugins.pydocstyle.addIgnore": {
-          "type": "array",
-          "default": null,
-          "items": {
-            "type": "string"
+          "pylsp.plugins.jedi_completion.include_class_objects": {
+            "type": "boolean",
+            "default": true,
+            "description": "Adds class objects as a separate completion item."
           },
-          "uniqueItems": true,
-          "description": "Ignore errors and warnings in addition to the specified convention."
-        },
-        "pyls.plugins.pydocstyle.addSelect": {
-          "type": "array",
-          "default": null,
-          "items": {
-            "type": "string"
+          "pylsp.plugins.jedi_completion.fuzzy": {
+            "type": "boolean",
+            "default": false,
+            "description": "Enable fuzzy when requesting autocomplete."
           },
-          "uniqueItems": true,
-          "description": "Select errors and warnings in addition to the specified convention."
-        },
-        "pyls.plugins.pydocstyle.ignore": {
-          "type": "array",
-          "default": null,
-          "items": {
-            "type": "string"
+          "pylsp.plugins.jedi_definition.enabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "Enable or disable the plugin."
           },
-          "uniqueItems": true,
-          "description": "Ignore errors and warnings"
-        },
-        "pyls.plugins.pydocstyle.select": {
-          "type": "array",
-          "default": null,
-          "items": {
-            "type": "string"
+          "pylsp.plugins.jedi_definition.follow_imports": {
+            "type": "boolean",
+            "default": true,
+            "description": "The goto call will follow imports."
           },
-          "uniqueItems": true,
-          "description": "Select errors and warnings"
-        },
-        "pyls.plugins.pydocstyle.match": {
-          "type": "string",
-          "default": "(?!test_).*\\.py",
-          "description": "Check only files that exactly match the given regular expression; default is to match files that don't start with 'test_' but end with '.py'."
-        },
-        "pyls.plugins.pydocstyle.matchDir": {
-          "type": "string",
-          "default": "[^\\.].*",
-          "description": "Search only dirs that exactly match the given regular expression; default is to match dirs which do not begin with a dot."
-        },
-        "pyls.plugins.pyflakes.enabled": {
-          "type": "boolean",
-          "default": false,
-          "description": "Enable or disable the plugin."
-        },
-        "pyls.plugins.pylint.enabled": {
-          "type": "boolean",
-          "default": false,
-          "description": "Enable or disable the plugin."
-        },
-        "pyls.plugins.pylint.args": {
-          "type": "array",
-          "default": null,
-          "items": {
-            "type": "string"
+          "pylsp.plugins.jedi_definition.follow_builtin_imports": {
+            "type": "boolean",
+            "default": true,
+            "description": "If follow_imports is True will decide if it follow builtin imports."
           },
-          "uniqueItems": false,
-          "description": "Arguments to pass to pylint."
-        },
-        "pyls.plugins.pylint.executable": {
-          "type": "string",
-          "default": null,
-          "description": "Executable to run pylint with. Enabling this will run pylint on unsaved files via stdin. Can slow down workflow. Only works with python3."
-        },
-        "pyls.plugins.rope_completion.enabled": {
-          "type": "boolean",
-          "default": false,
-          "description": "Enable or disable the plugin."
-        },
-        "pyls.plugins.yapf.enabled": {
-          "type": "boolean",
-          "default": false,
-          "description": "Enable or disable the plugin."
-        },
-        "pyls.rope.extensionModules": {
-          "type": "string",
-          "default": null,
-          "description": "Builtin and c-extension modules that are allowed to be imported and inspected by rope."
-        },
-        "pyls.rope.ropeFolder": {
-          "type": "array",
-          "default": null,
-          "items": {
-            "type": "string"
+          "pylsp.plugins.jedi_hover.enabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "Enable or disable the plugin."
           },
-          "uniqueItems": true,
-          "description": "The name of the folder in which rope stores project configurations and data.  Pass `null` for not using such a folder at all."
+          "pylsp.plugins.jedi_references.enabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "Enable or disable the plugin."
+          },
+          "pylsp.plugins.jedi_signature_help.enabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "Enable or disable the plugin."
+          },
+          "pylsp.plugins.jedi_symbols.enabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "Enable or disable the plugin."
+          },
+          "pylsp.plugins.jedi_symbols.all_scopes": {
+            "type": "boolean",
+            "default": true,
+            "description": "If True lists the names of all scopes instead of only the module namespace."
+          },
+          "pylsp.plugins.mccabe.enabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Enable or disable the plugin."
+          },
+          "pylsp.plugins.mccabe.threshold": {
+            "type": "number",
+            "default": 15,
+            "description": "The minimum threshold that triggers warnings about cyclomatic complexity."
+          },
+          "pylsp.plugins.preload.enabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "Enable or disable the plugin."
+          },
+          "pylsp.plugins.preload.modules": {
+            "type": "array",
+            "default": null,
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true,
+            "description": "List of modules to import on startup"
+          },
+          "pylsp.plugins.pycodestyle.enabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Enable or disable the plugin."
+          },
+          "pylsp.plugins.pycodestyle.exclude": {
+            "type": "array",
+            "default": null,
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true,
+            "description": "Exclude files or directories which match these patterns."
+          },
+          "pylsp.plugins.pycodestyle.filename": {
+            "type": "array",
+            "default": null,
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true,
+            "description": "When parsing directories, only check filenames matching these patterns."
+          },
+          "pylsp.plugins.pycodestyle.select": {
+            "type": "array",
+            "default": null,
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true,
+            "description": "Select errors and warnings"
+          },
+          "pylsp.plugins.pycodestyle.ignore": {
+            "type": "array",
+            "default": null,
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true,
+            "description": "Ignore errors and warnings"
+          },
+          "pylsp.plugins.pycodestyle.hangClosing": {
+            "type": "boolean",
+            "default": null,
+            "description": "Hang closing bracket instead of matching indentation of opening bracket's line."
+          },
+          "pylsp.plugins.pycodestyle.maxLineLength": {
+            "type": "number",
+            "default": null,
+            "description": "Set maximum allowed line length."
+          },
+          "pylsp.plugins.pydocstyle.enabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Enable or disable the plugin."
+          },
+          "pylsp.plugins.pydocstyle.convention": {
+            "type": "string",
+            "default": null,
+            "enum": [
+              "pep257",
+              "numpy"
+            ],
+            "description": "Choose the basic list of checked errors by specifying an existing convention."
+          },
+          "pylsp.plugins.pydocstyle.addIgnore": {
+            "type": "array",
+            "default": null,
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true,
+            "description": "Ignore errors and warnings in addition to the specified convention."
+          },
+          "pylsp.plugins.pydocstyle.addSelect": {
+            "type": "array",
+            "default": null,
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true,
+            "description": "Select errors and warnings in addition to the specified convention."
+          },
+          "pylsp.plugins.pydocstyle.ignore": {
+            "type": "array",
+            "default": null,
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true,
+            "description": "Ignore errors and warnings"
+          },
+          "pylsp.plugins.pydocstyle.select": {
+            "type": "array",
+            "default": null,
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true,
+            "description": "Select errors and warnings"
+          },
+          "pylsp.plugins.pydocstyle.match": {
+            "type": "string",
+            "default": "(?!test_).*\\.py",
+            "description": "Check only files that exactly match the given regular expression; default is to match files that don't start with 'test_' but end with '.py'."
+          },
+          "pylsp.plugins.pydocstyle.matchDir": {
+            "type": "string",
+            "default": "[^\\.].*",
+            "description": "Search only dirs that exactly match the given regular expression; default is to match dirs which do not begin with a dot."
+          },
+          "pylsp.plugins.pyflakes.enabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Enable or disable the plugin."
+          },
+          "pylsp.plugins.pylint.enabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Enable or disable the plugin."
+          },
+          "pylsp.plugins.pylint.args": {
+            "type": "array",
+            "default": null,
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": false,
+            "description": "Arguments to pass to pylint."
+          },
+          "pylsp.plugins.pylint.executable": {
+            "type": "string",
+            "default": null,
+            "description": "Executable to run pylint with. Enabling this will run pylint on unsaved files via stdin. Can slow down workflow. Only works with python3."
+          },
+          "pylsp.plugins.rope_completion.enabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Enable or disable the plugin."
+          },
+          "pylsp.plugins.yapf.enabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Enable or disable the plugin."
+          },
+          "pylsp.rope.extensionModules": {
+            "type": "string",
+            "default": null,
+            "description": "Builtin and c-extension modules that are allowed to be imported and inspected by rope."
+          },
+          "pylsp.rope.ropeFolder": {
+            "type": "array",
+            "default": null,
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true,
+            "description": "The name of the folder in which rope stores project configurations and data.  Pass `null` for not using such a folder at all."
+          }
         }
       }
-    },
+    ],
     "grammars": [
       {
         "language": "xonsh",

--- a/src/client.ts
+++ b/src/client.ts
@@ -22,7 +22,7 @@ export function activate(serverPath: string): Disposable {
     documentSelector: docSelector,
     synchronize: {
       fileEvents: workspace.createFileSystemWatcher('**/*.xonsh'),
-      configurationSection: 'pyls',
+      configurationSection: 'pylsp',
     },
     outputChannel: window.createOutputChannel('Xonsh'),
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import { UriMessageItem } from './models';
 
 function getExePath(): string | undefined {
   const executable = workspace
-    .getConfiguration('pyls')
+    .getConfiguration('pylsp')
     .get<string>('executable');
   if (executable) {
     const isWindows = process.platform === 'win32';
@@ -36,7 +36,7 @@ async function checkServerInstalled(): Promise<string | undefined> {
       'Unable to find Python language server',
       {
         title: 'Install language server',
-        uri: Uri.parse('https://github.com/palantir/python-language-server'),
+        uri: Uri.parse('https://github.com/python-lsp/python-lsp-server'),
       }
     );
     if (selection?.uri !== undefined) {


### PR DESCRIPTION
Hello, thanks for the great extension! I would like to update it so that it defaults to using [Python LSP Server](https://github.com/python-lsp/python-lsp-server), since the Palantir version seems abandoned.

Unfortunately I noticed that my VS Code "PROBLEMS" window reports several erroneous warnings from `pyflakes` and `pycodestyle` when using python-lsp-server, while this doesn't happen with Palantir. I don't really understand what's going on there. Any ideas?