### PR TITLE
set extensionKind to workspace & Use pylsp directly as the language server

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,13 +2,16 @@
   "name": "xonsh",
   "displayName": "Xonsh IDE",
   "description": "Xonsh language support.",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "publisher": "jnoortheen",
   "icon": "images/icon.png",
   "license": "MIT",
   "engines": {
     "vscode": ">=1.75.0"
   },
+  "extensionKind": [
+    "workspace"
+  ],
   "categories": [
     "Programming Languages",
     "Formatters",
@@ -362,7 +365,7 @@
     "@commitlint/cli": ">=16",
     "@commitlint/config-conventional": "*",
     "@types/node": "*",
-    "@types/vscode": "^1.64.0",
+    "@types/vscode": "^1.94.0",
     "@typescript-eslint/eslint-plugin": "*",
     "@typescript-eslint/parser": "*",
     "esbuild": "^0.14",
@@ -376,7 +379,7 @@
     "syntaxdev": "^0.1.3",
     "typescript": "*",
     "vsce": "^2",
-    "vscode": "^1.1.25",
+    "vscode": "^1.1.37",
     "watch": "^1.0.2"
   },
   "scripts": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -4,7 +4,6 @@ import {
   LanguageClientOptions,
   ServerOptions,
 } from 'vscode-languageclient/node';
-import * as net from "net";
 
 let client: LanguageClient;
 
@@ -27,34 +26,21 @@ function getClientOptions(): LanguageClientOptions {
 
 }
 
-function startLangServerTCP(addr: number): LanguageClient {
-    const serverOptions: ServerOptions = () => {
-        return new Promise((resolve /*, reject */) => {
-            const clientSocket = new net.Socket();
-            clientSocket.connect(addr, "127.0.0.1", () => {
-                resolve({
-                    reader: clientSocket,
-                    writer: clientSocket,
-                });
-            });
-        });
-    };
+export async function activate(
+  ctx: ExtensionContext, executable: string
+): Promise<void> {
+  const serverOptions: ServerOptions = {
+    command: executable,
+    args: ['-v'],
+  };
 
-    return new LanguageClient(
-        `tcp lang server (port ${addr})`,
-        serverOptions,
-        getClientOptions()
-    );
-}
+  client = new LanguageClient(
+    'pylsp',
+    'xonsh Python Language Server',
+    serverOptions,
+    getClientOptions()
+  );
 
-export async function activate(ctx: ExtensionContext): Promise<void> {
-  // const serverOptions: ServerOptions = {
-  //   command: "",
-  //   args: ['-v'],
-  // };
-
-  // client = new LanguageClient('xonsh', 'Xonsh', serverOptions, clientOptions);
-  client = startLangServerTCP(2007)
   client.registerProposedFeatures();
   await client.start();
   ctx.subscriptions.push(client);

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ export async function activate(ctx: ExtensionContext): Promise<void> {
   const executable = await checkServerInstalled();
 
   if (executable) {
-    await client.activate(ctx);
+    await client.activate(ctx, executable);
   }
 
   languages.setLanguageConfiguration('xonsh', {

--- a/yarn.lock
+++ b/yarn.lock
@@ -314,10 +314,10 @@
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.6.tgz#c65b2bfce1bec346582c07724e3f8c1017a20339"
   integrity sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==
 
-"@types/vscode@^1.64.0":
-  version "1.84.2"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.84.2.tgz#77b25d1db71f09e059f178622f831d704ee52b3a"
-  integrity sha512-LCe1FvCDMJKkPdLVGYhP0HRJ1PDop2gRVm/zFHiOKwYLBRS7vEV3uOOUId4HMV+L1IxqyS+IZXMmlSMRbZGIAw==
+"@types/vscode@^1.94.0":
+  version "1.94.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.94.0.tgz#ccd2111b6ecaba6ad4da19c2d524828fa73ae250"
+  integrity sha512-UyQOIUT0pb14XSqJskYnRwD2aG0QrPVefIfrW1djR+/J4KeFQ0i1+hjZoaAmeNf3Z2jleK+R2hv+EboG/m8ruw==
 
 "@typescript-eslint/eslint-plugin@*":
   version "6.13.1"
@@ -3872,7 +3872,7 @@ vscode-test@^0.4.1:
     http-proxy-agent "^2.1.0"
     https-proxy-agent "^2.2.1"
 
-vscode@^1.1.25:
+vscode@^1.1.37:
   version "1.1.37"
   resolved "https://registry.yarnpkg.com/vscode/-/vscode-1.1.37.tgz#c2a770bee4bb3fff765e2b72c7bcc813b8a6bb0a"
   integrity sha512-vJNj6IlN7IJPdMavlQa1KoFB3Ihn06q1AiN3ZFI/HfzPNzbKZWPPuiU+XkpNOfGU5k15m4r80nxNPlM7wcc0wg==


### PR DESCRIPTION
This change was the way to make it work for me.
I use it in a Windows environment but in WSL 2.

This probably fixes #90

Was not clear to me if the `pylsp` need to be run apart from the extension, in my environment it was blocked in the `client.start` forever, but using it directly worked.