### PR TITLE
Add $!@()[] subprocess/eval operators to textmate grammar

### DIFF
--- a/src/tmlang/xonsh.syntax.yaml
+++ b/src/tmlang/xonsh.syntax.yaml
@@ -1569,7 +1569,7 @@ repository:
   illegal-operator:
     patterns:
       - name: invalid.illegal.operator.python
-        match: '&&|\|\||--|\+\+'
+        match: '--|\+\+'
       - name: invalid.illegal.operator.python
         match: '[?]'
       - name: invalid.illegal.operator.python

--- a/src/tmlang/xonsh.syntax.yaml
+++ b/src/tmlang/xonsh.syntax.yaml
@@ -204,6 +204,83 @@ repository:
         guard: ""
 
 
+  xonsh-operator:
+    patterns:
+      - match: '(\$)([A-Za-z_][A-Za-z0-9_]*)\b'
+        captures:
+          '1': {name: keyword.operator.xonsh}
+          '2': {name: constant.other.caps.python}
+
+      - name: meta.scope.subshell.xonsh.captured.command
+        begin: '@\$\('
+        end: '\)'
+        beginCaptures:
+          '0': {name: constant.character
+                      punctuation.definition.subshell.single.shell}
+        endCaptures:
+          '0': {name: constant.character
+                      punctuation.definition.subshell.single.shell}
+        patterns:
+          - include: '#xonsh-operator'
+          - include: '#round-braces'
+          - include: '#list'
+          - include: '#curly-braces'
+
+      - name: meta.scope.subshell.xonsh.captured.output
+        begin: '\$\('
+        end: '\)'
+        beginCaptures:
+          '0': {name: constant.character
+                      punctuation.definition.subshell.single.shell}
+        endCaptures:
+          '0': {name: constant.character
+                      punctuation.definition.subshell.single.shell}
+        patterns:
+          - include: '#xonsh-operator'
+          - include: '#round-braces'
+          - include: '#list'
+          - include: '#curly-braces'
+
+      - name: meta.scope.subshell.xonsh.captured.object
+        begin: '!\('
+        end: '\)'
+        beginCaptures:
+          '0': {name: constant.character
+                      punctuation.definition.subshell.single.shell}
+        endCaptures:
+          '0': {name: constant.character
+                      punctuation.definition.subshell.single.shell}
+        patterns:
+          - include: '#xonsh-operator'
+          - include: '#round-braces'
+          - include: '#list'
+          - include: '#curly-braces'
+
+      - name: meta.scope.subshell.xonsh.uncaptured
+        begin: '[$!]\['
+        end: '\]'
+        beginCaptures:
+          '0': {name: constant.character
+                      punctuation.definition.subshell.single.shell}
+        endCaptures:
+          '0': {name: constant.character
+                      punctuation.definition.subshell.single.shell}
+        patterns:
+          - include: '#xonsh-operator'
+          - include: '#round-braces'
+          - include: '#list'
+          - include: '#curly-braces'
+
+      - name: meta.xonsh.python-eval
+        begin: '@\('
+        end: '\)'
+        beginCaptures:
+          '0': {name: constant.character}
+        endCaptures:
+          '0': {name: constant.character}
+        patterns:
+          - include: '#expression'
+
   impossible:
     comment: This is a special rule that should be used where no match
              is desired. It is not a good idea to match something like
@@ -398,6 +475,7 @@ repository:
       - include: '#string'
       - include: '#lambda'
       - include: '#generator'
+      - include: '#xonsh-operator'
       - include: '#illegal-operator'
       - include: '#operator'
       - include: '#curly-braces'
@@ -1493,10 +1571,7 @@ repository:
       - name: invalid.illegal.operator.python
         match: '&&|\|\||--|\+\+'
       - name: invalid.illegal.operator.python
-        match: '[?$]'
-      - name: invalid.illegal.operator.python
-        comment: We don't want `!` to flash when we're typing `!=`
-        match: '!\b'
+        match: '[?]'
 
   illegal-object-name:
     comment: It's illegal to name class or function "True"

--- a/src/tmlang/xonsh.syntax.yaml
+++ b/src/tmlang/xonsh.syntax.yaml
@@ -1572,6 +1572,9 @@ repository:
         match: '&&|\|\||--|\+\+'
       - name: invalid.illegal.operator.python
         match: '[?]'
+      - name: invalid.illegal.operator.python
+        comment: We don't want `!` to flash when we're typing `!=`
+        match: '$!\b'
 
   illegal-object-name:
     comment: It's illegal to name class or function "True"


### PR DESCRIPTION
Hi @jnoortheen!

I've been using Xonsh for a little more than a month and I find it very cool :)

I just created a JetBrains plugin for it: https://github.com/nahoj/xonsh-jetbrains. I was able to get a functional plugin relatively quickly (notwithstanding the messy README) by using the TextMate grammar from your plugin for syntax highlighting, and [xonsh-language-server](https://github.com/FoamScience/xonsh-language-server) for everything else. 

Then I added operators `$() !() @$() $[] ![] @()` as well as environment variables to the grammar, hence this PR.

However, I didn't test the result in VSCode because I didn't manage to install it from source. I didn't invest too much time in it as I don't really use VSCode.

I also didn't manage to get `syntaxdev` running on my computer as `oniguruma` wouldn't build. So instead I used [a vibe-coded Python script](https://github.com/nahoj/xonsh-jetbrains/blob/main/scripts/resolve_grammar.py) to build the grammar JSON from the YAML templates.

I saw that you're not actively developing this plugin, so I would understand if you didn't want to merge this.

If you're interested in merging this and potentially a few more changes, we could consider this repo the reference and I'd make it a git submodule of mine to build the plugin, or something like that.