### PR TITLE
Remove invalid.deprecated.backtick.python pattern to allow for globbing

### DIFF
--- a/src/tmlang/xonsh.syntax.yaml
+++ b/src/tmlang/xonsh.syntax.yaml
@@ -1559,13 +1559,6 @@ repository:
     name: constant.other.ellipsis.python
     match: \.\.\.
 
-  backticks:
-    name: invalid.deprecated.backtick.python
-    begin: \`
-    end: (?:\`|(?<!\\)(\n))
-    patterns:
-      - include: '#expression'
-
   illegal-operator:
     patterns:
       - name: invalid.illegal.operator.python


### PR DESCRIPTION
So that this doesn't get highlighted in defcon 1 fashion (at least in Jetbrains):

```xsh
g`...`
```
